### PR TITLE
Add --recent option, only output recent updated files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ repomaster --version
 # Show help
 repomaster -h
 repomaster --help
+
+# list recent modified files (within last 7 days) only
+repomaster . -r
+repomaster . --recent
+
+# list recent modified files (within last N days) only
+repomaster . -r 14
+repomaster . --recent 30
 ```
 
 ## Example Output

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,7 @@ program
   .argument('<paths...>', 'one or more files/directories (use . for current)') // receive 1+ paths
   .option('-o, --output <file>', 'output to a file instead of stdout')
   .option('--no-gitignore', 'do not use .gitignore rules (include all files)')
-  .option('-r, --recent [days]', 'only include the most recently (7 days) modified files per directory')
+  .option('-r, --recent [days]', 'only include the most recently (7 days) modified files per directory. \n-r(default 7days), -r [days] could show custom days')
   .action((paths, options) => {
     // convert to absolute paths
     const absPaths = paths.map(p => path.resolve(p));


### PR DESCRIPTION
fix #5 
Introducing a new --recent option for this project

basic use case
```bash
# list recent modified files (within last 7 days) only
repomaster . -r
repomaster . --recent

# list recent modified files (within last N days) only
repomaster . -r 14
repomaster . --recent 30
```

the working directory on testing machine
```bash
❯ ls -al
total 128
drwxr-xr-x@ 12 phillips  staff    384 Sep 18 17:15 .
drwxr-xr-x  17 phillips  staff    544 Sep 14 19:00 ..
drwxr-xr-x@ 15 phillips  staff    480 Sep 18 21:13 .git
-rw-r--r--@  1 phillips  staff   2171 Sep 18 17:15 .gitignore
drwxr-xr-x@  3 phillips  staff     96 Sep 11 22:39 bin
-rw-r--r--@  1 phillips  staff   1065 Sep 11 22:39 LICENSE
drwxr-xr-x@  5 phillips  staff    160 Sep 18 20:09 node_modules
-rw-r--r--@  1 phillips  staff  43752 Sep 18 20:58 output.txt
-rw-r--r--@  1 phillips  staff   1066 Sep 18 20:09 package-lock.json
-rw-r--r--@  1 phillips  staff    866 Sep 18 17:15 package.json
-rw-r--r--@  1 phillips  staff   2321 Sep 18 21:12 README.md
drwxr-xr-x@  8 phillips  staff    256 Sep 18 17:15 src
```
the partial output **without** --recent option
```bash
repomaster .  
```
~~~
...
## Structure
```
bin/
  repomaster.js
src/
  cli.js
  content-handler.js
  file-scanner.js
  git-info.js
  gitignore-handler.js
  tree-builder.js
.gitignore
LICENSE
output.txt
package-lock.json
package.json
README.md
```
...
~~~
the partial output **with** --recent option
```bash
repomaster .  --recent 1 
```
~~~
...
## Structure
```
src/
  cli.js
  content-handler.js
  file-scanner.js
  git-info.js
  gitignore-handler.js
  tree-builder.js
.gitignore
output.txt
package-lock.json
package.json
README.md
```
...
~~~

Some files be excluded if their last modified date exceeds 1 day.
Let me know if I can improve this pull request
