### PR TITLE
Add TOML config file support

### DIFF
--- a/.repomaster-config.toml
+++ b/.repomaster-config.toml
@@ -1,0 +1,14 @@
+# Output file path - where to write the repository context
+output = 'output.txt'
+
+# Include all files, ignore .gitignore rules
+noGitIgnore = false
+
+# Include line numbers in file content output
+lineNumbers = true
+
+# List recent modified files (within last 5 days) only
+recent = 5
+
+# Include line numbers in file content output
+grep = 'repomaster'

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ Instead of copy-pasting code file by file, RepoMaster automatically collects:
 - **Customizable Scope**: Process entire directories or specific files
 - **Line Numbers**: Optional line numbers display for easier code reference
 - **Content Search**: Filter files by content using regex patterns with `--grep`
+- **Configuration File**: Making some optional features by default
+  You can modify the `.repomaster-config.toml` file in your repository to set default options:
+
+  ```toml
+  # Output file path - where to write the repository context
+  output = 'output.txt'
+
+  # Include all files, ignore .gitignore rules
+  noGitIgnore = false
+
+  # Include line numbers in file content output
+  lineNumbers = true
+
+  # List recent modified files (within last 5 days) only
+  recent = 5
+
+  # Include line numbers in file content output
+  grep = 'repomaster'
+  ```
+  - If the config file doesn't exist, it will be ignored
+  - Command line arguments override config file settings
+  - Invalid TOML files will cause the tool to exit with an error
+  - Unrecognized options are ignored for future extensibility
 
 ## Installation
 
@@ -31,7 +54,7 @@ npm link
 
 ## Example Usage
 ```bash
-# Package the current directory, Use .gitignore by default (exclude ignored files)
+# Package the current directory, Use .gitignore and `-o output.txt` by default (exclude ignored files)
 repomaster .
 
 # Include all files, ignore .gitignore rules  
@@ -69,6 +92,7 @@ repomaster . --recent 30
 # Include line numbers in file content output
 repomaster . -l
 repomaster . --line-numbers
+
 # Filter files by content pattern (case-insensitive regex search)
 repomaster . --grep "Command"
 repomaster . --grep "import.*React"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import fs from 'node:fs'; 
 import path from 'node:path';
 import { getGitInfoOrNull } from './git-info.js';
@@ -6,6 +6,10 @@ import { collectFiles } from './file-scanner.js';
 import { buildTree, renderTree } from './tree-builder.js';
 import { readFilesAndSummarize, isLikelyBinary } from './content-handler.js';
 import { isBooleanObject } from 'node:util/types';
+import { loadTomlConfig } from './toml-config.js'
+
+// load config from TOML
+const tomlConfig = loadTomlConfig();
 
 const program = new Command();
 
@@ -14,11 +18,11 @@ program
   .description('Repository Context Packager - package repo context for LLMs')
   .version('0.1.0')   // --version / -V
   .argument('<paths...>', 'one or more files/directories (use . for current)') // receive 1+ paths
-  .option('-o, --output <file>', 'output to a file instead of stdout')
-  .option('--no-gitignore', 'do not use .gitignore rules (include all files)')
-  .option('-r, --recent [days]', 'only include the most recently (7 days) modified files per directory. \n-r(default 7days), -r [days] could show custom days')
-  .option('-l, --line-numbers', 'include line numbers in file content output')
-  .option('--grep <pattern>', 'only include files containing the specified pattern')
+  .addOption(new Option('-o, --output <file>', 'output to a file instead of stdout').default(tomlConfig.output))
+  .addOption(new Option('--no-gitignore', 'do not use .gitignore rules (include all files)').default(tomlConfig.noGitIgnore))
+  .addOption(new Option('-r, --recent [days]', 'only include the most recently (7 days) modified files per directory. \n-r(default 7days), -r [days] could show custom days').default(tomlConfig.recent))
+  .addOption(new Option('-l, --line-numbers', 'include line numbers in file content output').default(tomlConfig.lineNumbers))
+  .addOption(new Option('--grep <pattern>', 'only include files containing the specified pattern').default(tomlConfig.grep))
   .action((paths, options) => {
     // convert to absolute paths
     const absPaths = paths.map(p => path.resolve(p));

--- a/src/file-scanner.js
+++ b/src/file-scanner.js
@@ -41,7 +41,7 @@ export function collectFiles(absInputs, useGitignore = true) {
     
     if (st.isDirectory()) {
       // If it's a directory, explore all files inside it recursively
-      walkDir(p, out, seen, gitignoreInfo);
+      walkDir(p, out, seen, gitignoreInfo, useGitignore);
     } else if (st.isFile()) {
       // If it's a file and we haven't seen it before, add it to our list
       if (!seen.has(p)) { out.push(p); seen.add(p); }
@@ -54,7 +54,7 @@ export function collectFiles(absInputs, useGitignore = true) {
 }
 
 // explore a directory and all its subdirectories recursively
-function walkDir(dir, out, seen, gitignoreInfo = null) {
+function walkDir(dir, out, seen, gitignoreInfo = null, useGitignore) {
   let entries;  
   try {
     // Try to read all files and folders in this directory
@@ -72,7 +72,7 @@ function walkDir(dir, out, seen, gitignoreInfo = null) {
 
     // Skip certain directories that we don't want to include
     // .git contains Git's internal files, node_modules contains downloaded libraries
-    if (ent.isDirectory?.() && DEFAULT_EXCLUDED_DIRS.has(name)) {
+    if (useGitignore && ent.isDirectory?.() && DEFAULT_EXCLUDED_DIRS.has(name)) {
       continue;  // Skip this directory and move to the next item
     }
     

--- a/src/toml-config.js
+++ b/src/toml-config.js
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import toml from 'toml';
+
+/**
+ * Load configuration from .repomaster-config.toml if exists
+ */
+export function loadTomlConfig(configPath = '.repomaster-config.toml') {
+  const fullPath = path.resolve(configPath);
+  if (!fs.existsSync(fullPath)) return {};
+
+  try {
+    const content = fs.readFileSync(fullPath, 'utf-8');
+    return toml.parse(content);
+  } catch (error) {
+    console.error(`Error parsing TOML config: ${error.message}`);
+    return {};
+  }
+}


### PR DESCRIPTION
### Summary

This PR based on the issue #9 and creates a configuration TOML file settings with `.repomaster-config.toml`. Which allows users can have some options features using by default. 

### What's Changed

* Add `src/toml-config.js` to load the TOML configuration
* Modify `src/cli.js` to read TOML configuration and runs some features as default successfully
* CLI `--no-line-numbers` now correctly disables line numbers even if the config file sets it to `true`.
* Add descriptions in `README.md` file about this change.

### Usage sample
```
# Save the output into output.txt file and with line number for each line
repomaster .
```